### PR TITLE
Add debug configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+*.pdb
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/setup.py
+++ b/setup.py
@@ -122,10 +122,17 @@ class CustomBuildExt(build_ext):
                 "/EHsc",
                 "/W4",
                 "/fp:precise",
+                # https://github.com/mos9527/sssekai_blender_io/issues/11
+                "/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR",
             ]
             # not in the astc-encoder CMakeLists.txt
-            # evem tho it should improve performance
+            # even tho it should improve performance
             extra_link_args = ["/LTCG:incremental"]
+            # Enable debug build if specified
+            if os.environ.get("DEBUG", False):
+                extra_compile_args.append("/Od")
+                extra_compile_args.append("/Zi")
+                extra_link_args.append("/debug")
             msvc = True
         else:
             extra_compile_args = [

--- a/setup.py
+++ b/setup.py
@@ -124,8 +124,6 @@ class CustomBuildExt(build_ext):
                 "/EHsc",
                 "/W4",
                 "/fp:precise",
-                # https://github.com/mos9527/sssekai_blender_io/issues/11
-                "/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR",
             ]
             # not in the astc-encoder CMakeLists.txt
             # even tho it should improve performance

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,8 @@ configs = {
 
 
 class CustomBuildExt(build_ext):
+    ENV_DEBUG_INFO = "DEBUG_INFO"
+
     def build_extensions(self):
         extra_compile_args: List[str] = []
         extra_link_args: List[str] = []
@@ -128,8 +130,8 @@ class CustomBuildExt(build_ext):
             # not in the astc-encoder CMakeLists.txt
             # even tho it should improve performance
             extra_link_args = ["/LTCG:incremental"]
-            # Enable debug build if specified
-            if os.environ.get("DEBUG", False):
+            # Generate debug info if specified (MSVC)
+            if os.environ.get(self.ENV_DEBUG_INFO, False):
                 extra_compile_args.append("/Od")
                 extra_compile_args.append("/Zi")
                 extra_link_args.append("/debug")
@@ -142,6 +144,11 @@ class CustomBuildExt(build_ext):
                 "-ffp-contract=fast",
             ]
             extra_link_args = ["-flto"]
+
+            # Generate debug info if specified (GCC/Clang/Mingw/etc)
+            if os.environ.get(self.ENV_DEBUG_INFO, False):
+                extra_compile_args.append("-O0")
+                extra_compile_args.append("-ggdb")
 
             if not cibuildwheel:
                 # do some native optimizations for the current machine


### PR DESCRIPTION
TL;DR: This PR address the issue where the Windows MSVC builds of the extension would cause a `Read Access Violation` crash due to mismatched Visual C++ Redistributable DLLs on certain platforms.

Additionally, this PR adds an environment build flag (`DEBUG`) for MSVC builds to allow the extension to be built with debug information, since `pip` doesn't seem to provide a switch for it. This is used in my own debugging process.

A (not so formal) write up about the change is posted here, detailing one edge case where this issue may actually manifest.
- https://github.com/mos9527/sssekai_blender_io/issues/11

The fix proposed by this PR does seem to remedy the said issue as per my limited testing.

