### PR TITLE
Attempt to fix ref count memory leak caused by ASTCContext.decompress

### DIFF
--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -673,7 +673,7 @@ PyObject *ASTCContext_method_decompress(ASTContextT *self, PyObject *args, PyObj
     }
 
     // create a python bytes object from the decompressed data
-    Py_IncRef(py_image_data);
+    // Py_IncRef(py_image_data); // ref count is already increased by PyBytes_FromStringAndSize
     Py_DecRef(py_image->data);
     py_image->data = py_image_data;
 


### PR DESCRIPTION
*Disclaimer: I am not quite familiar with C extension interface, but tracking down from the memory leak from `UnityPy.export.Texture2DConverter.astc` leads me here. The description is mainly based on the official documentation.*

It seems that the line [PyBytes_FromStringAndSize](https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromStringAndSize) has already created a new Python `bytes` object with a new reference.

When the decompression is unsuccessful, `py_image_data` is unused and thus the two `Py_DecRef(py_image_data)` seems to be done appropriately.
If the decompression is successful, it is then assigned to `py_image->data`, replacing the old reference. Therefore, it is still the ***only*** reference the `bytes` object is referenced in Python, and `Py_IncRef(py_image_data)` that increases the difference of reference count between fail and success to 2 seems to be faulty.

I suppose that this is a source of memory leak.

Locally built and tested with my own use case and the RAM Usage stops increasing per Texture load.

Test:
```py
def test_unity_image_memory():
    import UnityPy
    from tqdm import tqdm
    import gc
    with open("<path>", "rb") as f:
        content = f.read()
    for cnt in tqdm(range(10000)):
        f = UnityPy.load(content)
        if cnt % 1 == 0:
            try:
                with open('/proc/self/status') as f2:
                    parts = [line.split(":") for line in f2.read().strip().split("\n")]
                    lookup = {line[0].strip(): line[1].strip() for line in parts}
                    print(f'Physical RAM Usage: {lookup["VmRSS"]}')
            except:
                pass
        images = [o.read().image for o in f.objects if o.type.name in ('Sprite', 'Texture2D')]
        images[0].save("_temp/{}.png".format(cnt))
        gc.collect()
```